### PR TITLE
refactor(scripts): move to scripts.nix

### DIFF
--- a/scripts.nix
+++ b/scripts.nix
@@ -1,0 +1,43 @@
+{ writeScriptBin, nix, nixpkgs-fmt }:
+{
+  update = writeScriptBin "update"
+    ''
+      for dir in `ls -d */`; do
+        (
+          cd $dir
+          ${nix}/bin/nix flake update # Update flake.lock 
+          ${nix}/bin/nix develop $dir # Make sure this work after update
+        )
+      done
+    '';
+
+  test-develop = writeScriptBin "test-develop"
+    ''
+      for dir in `ls -d */`; do
+        (
+          ${nix}/bin/nix develop $dir # Make sure this work after update
+          sleep 0.2
+        )
+      done
+    '';
+
+  format = writeScriptBin "format"
+    ''
+      ${nixpkgs-fmt}/bin/nixpkgs-fmt **/*.nix
+    '';
+
+  dvt = writeScriptBin "dvt"
+    ''
+      if [ -z $1 ]; then
+        echo "no template specified"
+        exit 1
+      fi
+      TEMPLATE=$1
+      ${nix}/bin/nix \
+        --experimental-features 'nix-command flakes' \
+        flake init \
+        --template \
+        "github:efishery/dvt#''${TEMPLATE}"
+    '';
+}
+


### PR DESCRIPTION
Features:
* overlay `dvt.overlay.default`
* expose scripts in `packages`
```bash
❯ nix flake show
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───overlay: Nixpkgs overlay
├───packages
│   ├───aarch64-darwin
│   │   ├───dvt-format: package 'format'
│   │   ├───dvt-init: package 'dvt'
│   │   ├───dvt-update: package 'update'
│   │   └───test-develop: package 'test-develop'
│   ├───aarch64-linux
│   │   ├───dvt-format: package 'format'
│   │   ├───dvt-init: package 'dvt'
│   │   ├───dvt-update: package 'update'
│   │   └───test-develop: package 'test-develop'
│   ├───x86_64-darwin
│   │   ├───dvt-format: package 'format'
│   │   ├───dvt-init: package 'dvt'
│   │   ├───dvt-update: package 'update'
│   │   └───test-develop: package 'test-develop'
│   └───x86_64-linux
│       ├───dvt-format: package 'format'
│       ├───dvt-init: package 'dvt'
│       ├───dvt-update: package 'update'
│       └───test-develop: package 'test-develop'
└───templates
    ├───go: template: Go development environment
    ├───node: template: Nodejs development environment
    ├───node14: template: Nodejs (v14) and pnpm (v5) development environment
    └───react-native: template: React Native development environment
```

